### PR TITLE
[Fix] 인디케이터 중복 삭제

### DIFF
--- a/AnglesRecord_IOS/AnglesRecord_IOS/Feature/Main/MainView.swift
+++ b/AnglesRecord_IOS/AnglesRecord_IOS/Feature/Main/MainView.swift
@@ -27,10 +27,6 @@ struct MainView: View {
         ZStack(alignment: .bottom) {
             ScrollView {
                 VStack(spacing: 0) {
-                    if isRefreshing {
-                        ProgressView().padding(.vertical, 12)
-                    }
-
                     podcastMainSection
 
                     Divider().padding(.horizontal)


### PR DESCRIPTION
## 어떤 이슈와 관련있나요?
<!-- #과 함께 이슈번호를 넣으세요! -->
closes #83 
![4DC65F83-4317-41AC-B1D5-76AF0580B54D_1_102_o](https://github.com/user-attachments/assets/6db4b91c-d7b4-4b8d-84b6-81769e73b4e0)



인디케이터 2개 중복으로 뜨던 거 하나 삭제했습니당