### PR TITLE
[Fix] 날짜오류 수정

### DIFF
--- a/AnglesRecord_IOS/AnglesRecord_IOS/Feature/Main/MainView.swift
+++ b/AnglesRecord_IOS/AnglesRecord_IOS/Feature/Main/MainView.swift
@@ -17,8 +17,13 @@ struct MainView: View {
     @StateObject private var audioPlayer = AudioPlayerManager()
     @State private var showingFilePicker = false
     @State private var selectedRecord: RecordListModel?
+
     @AppStorage("isDarkMode") private var isDarkMode = false
     @AppStorage("shouldFetchNewEpisodes") private var shouldFetchNewEpisodes = false
+
+    // ✅ 1회 백필 여부 플래그
+    @AppStorage("didBackfillUploadedAt") private var didBackfillUploadedAt = false
+
     @State private var showingPlayerView = false
     @State private var isLoading = false
     @State private var isRefreshing = false
@@ -62,7 +67,14 @@ struct MainView: View {
                             .map { ep in
                                 let url = recordListViewModel.getLocalFileURL(for: ep.fileName)
                                 let duration = CMTimeGetSeconds(AVURLAsset(url: url).duration)
-                                return RecordListModel(title: ep.title, artist: formatted(date: ep.uploadedAt), duration: duration, fileURL: url)
+                                // ✅ 업로드 날짜를 RecordListModel에 전달
+                                return RecordListModel(
+                                    title: ep.title,
+                                    artist: formatted(date: ep.uploadedAt),
+                                    duration: duration,
+                                    fileURL: url,
+                                    uploadedAt: ep.uploadedAt
+                                )
                             }
                             .filter { $0.id != selected.id }
 
@@ -83,7 +95,17 @@ struct MainView: View {
         ) { handleFileImport($0) }
         .onAppear {
             print("👀 [\(TS())] MainView.onAppear")
-            loadInitialData()
+            // 1) 로컬 먼저
+            recordListViewModel.loadLocalEpisodes(context: modelContext)
+
+            // 2) (필요 시) 1회 백필
+            backfillUploadedAtOnceIfNeeded()
+
+            // 3) 푸시 플래그 감지 시 자동 동기화
+            if shouldFetchNewEpisodes {
+                print("📥 [\(TS())] 푸시 감지됨 → 자동 동기화")
+                Task { await refreshNow(trigger: "onAppear-flag") }
+            }
         }
         .onChange(of: shouldFetchNewEpisodes) { newVal in
             print("🔁 [\(TS())] shouldFetchNewEpisodes 변경: \(newVal)")
@@ -120,14 +142,59 @@ struct MainView: View {
         print("🏁 [\(TS())] refreshNow 종료")
     }
 
-    // MARK: - 초기 로딩
-    private func loadInitialData() {
-        print("📦 [\(TS())] 로컬 먼저 로드")
-        recordListViewModel.loadLocalEpisodes(context: modelContext)
+    // MARK: - 1회 백필
+    /// 기존에 저장된 RecordListModel 중 uploadedAt이 비어있는 항목을 채워줍니다.
+    /// - 우선순위: 파일명 매칭 → 제목 매칭 → 기존 addedDate
+    private func backfillUploadedAtOnceIfNeeded() {
+        guard !didBackfillUploadedAt else {
+            print("↪️ [\(TS())] 백필 스킵: 이미 완료됨")
+            return
+        }
+        print("🛠️ [\(TS())] 백필 시작")
 
-        if shouldFetchNewEpisodes {
-            print("📥 [\(TS())] 푸시 감지됨 → 자동 동기화")
-            Task { await refreshNow(trigger: "onAppear-flag") }
+        do {
+            // 1) 모든 에피소드와 레코드 로드
+            let episodes = try modelContext.fetch(FetchDescriptor<EpisodeModel>())
+            var episodeByFileName: [String: EpisodeModel] = [:]
+            var episodeByTitle: [String: EpisodeModel] = [:]
+            for ep in episodes {
+                episodeByFileName[ep.fileName] = ep
+                episodeByTitle[ep.title] = ep
+            }
+
+            let records = try modelContext.fetch(FetchDescriptor<RecordListModel>())
+            var patched = 0
+
+            for rec in records {
+                // 이미 채워져 있으면 스킵 (모델에 uploadedAt이 Optional이라고 가정)
+                if rec.uploadedAt != nil { continue }
+
+                // 파일명 매칭
+                var matchedDate: Date? = nil
+                if let url = rec.fileURL {
+                    let name = url.lastPathComponent
+                    if let ep = episodeByFileName[name] {
+                        matchedDate = ep.uploadedAt
+                    }
+                }
+
+                // 제목 매칭(보조)
+                if matchedDate == nil, let ep = episodeByTitle[rec.title] {
+                    matchedDate = ep.uploadedAt
+                }
+
+                // 최종 fallback: 기존 추가일
+                rec.uploadedAt = matchedDate ?? rec.addedDate
+                patched += 1
+            }
+
+            try modelContext.save()
+            didBackfillUploadedAt = true
+            print("✅ [\(TS())] 백필 완료: \(patched)건 패치됨")
+
+        } catch {
+            print("❌ [\(TS())] 백필 실패: \(error.localizedDescription)")
+            // 실패해도 앱 동작에는 영향 없도록 플래그는 그대로 둠
         }
     }
 
@@ -239,11 +306,13 @@ struct MainView: View {
         let asset = AVURLAsset(url: localURL)
         let duration = CMTimeGetSeconds(asset.duration)
 
+        // ✅ 플레이용 RecordListModel에도 업로드 날짜를 넣어준다
         let record = RecordListModel(
             title: episode.title,
-            artist: episode.desc,
+            artist: episode.desc, // 미니플레이어에서는 날짜 표시는 formattedDate로 처리
             duration: duration,
-            fileURL: localURL
+            fileURL: localURL,
+            uploadedAt: episode.uploadedAt
         )
 
         withAnimation(.spring()) {
@@ -273,11 +342,13 @@ struct MainView: View {
                 let asset = AVURLAsset(url: destinationURL)
                 let duration = CMTimeGetSeconds(asset.duration)
 
+                // ✅ 로컬로 가져온 파일은 uploadedAt이 없으므로 nil (formattedDate가 addedDate로 표시)
                 let newRecord = RecordListModel(
                     title: url.deletingPathExtension().lastPathComponent,
                     artist: "Unknown Artist",
                     duration: duration,
-                    fileURL: destinationURL
+                    fileURL: destinationURL,
+                    uploadedAt: nil
                 )
 
                 modelContext.insert(newRecord)
@@ -321,8 +392,4 @@ struct MainView: View {
         modelContext.delete(record)
         try? modelContext.save()
     }
-}
-
-#Preview {
-    MainView().environmentObject(RecordListViewModel())
 }

--- a/AnglesRecord_IOS/AnglesRecord_IOS/Feature/Player/PlayerView.swift
+++ b/AnglesRecord_IOS/AnglesRecord_IOS/Feature/Player/PlayerView.swift
@@ -107,7 +107,7 @@ struct PlayerView: View {
 
                     if isExpanded {
                         VStack(spacing: 4) {
-                            Text(formattedDate(record.addedDate))
+                            Text(record.formattedDate)
                                 .font(.caption)
                                 .foregroundColor(.subText)
                                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -372,13 +372,6 @@ struct PlayerView: View {
         let maxOffset: CGFloat = 300
         let scale = 1 - (min(dragOffset, maxOffset) / maxOffset) * 0.1
         return scale
-    }
-
-    private func formattedDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM d"
-        formatter.locale = Locale(identifier: "en_US")
-        return formatter.string(from: date)
     }
 
     private func startVolumeAnimation() {

--- a/AnglesRecord_IOS/AnglesRecord_IOS/Feature/RecordList/Model/RecordListModel.swift
+++ b/AnglesRecord_IOS/AnglesRecord_IOS/Feature/RecordList/Model/RecordListModel.swift
@@ -9,25 +9,36 @@ final class RecordListModel {
     var duration: TimeInterval
     var fileURL: URL?
     var addedDate: Date
+    var uploadedAt: Date?
 
-    init(title: String, artist: String, duration: TimeInterval, fileURL: URL? = nil) {
+    init(title: String, artist: String, duration: TimeInterval, fileURL: URL? = nil, uploadedAt: Date? = nil) {
         self.id = UUID()
         self.title = title
         self.artist = artist
         self.duration = duration
         self.fileURL = fileURL
         self.addedDate = Date()
+        self.uploadedAt = uploadedAt
+    }
+
+    private var displayDate: Date { uploadedAt ?? addedDate }
+    
+    private enum DateCache {
+        static let displayFormatter: DateFormatter = {
+            let f = DateFormatter()
+            f.dateFormat = "M월 d일"
+            f.locale = Locale(identifier: "ko_KR")
+            return f
+        }()
+    }
+
+    var formattedDate: String {
+        DateCache.displayFormatter.string(from: displayDate)
     }
 
     var formattedDuration: String {
         let minutes = Int(duration) / 60
         let seconds = Int(duration) % 60
         return String(format: "%d:%02d", minutes, seconds)
-    }
-
-    var formattedDate: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.M.d"
-        return formatter.string(from: addedDate)
     }
 }


### PR DESCRIPTION
## 어떤 이슈와 관련있나요?
<!-- #과 함께 이슈번호를 넣으세요! -->
closes #88 

## 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 날짜 오류를 수정하기 위해서 RecordListModel에 옵셔널 파라미터를 추가했습니다. (uploadedAt)
- 기존 사용자의 경우 해당 값이 없어서, mainview에서 백필로 EpisodeModel의 uploadedAt을 복사해옵니다.
- 추가로, EpisodeModel에서 날자 포맷을 캐시화 시켰습니다.

<img width="1179" height="2556" alt="KakaoTalk_Photo_2025-08-25-00-53-32 002" src="https://github.com/user-attachments/assets/da71f996-9611-4611-9b0d-55d95f07ef70" />
<img width="1179" height="2556" alt="KakaoTalk_Photo_2025-08-25-00-53-31 001" src="https://github.com/user-attachments/assets/2c919aae-a193-4956-97d5-577e847fdcba" />
<img width="1179" height="2556" alt="KakaoTalk_Photo_2025-08-25-00-53-32 003" src="https://github.com/user-attachments/assets/50641b73-882b-4376-902c-3d2fc6239441" />


