### PR TITLE
[Feat] 업데이트 발생 시 앱 사용 차단 로직 적용

### DIFF
--- a/AnglesRecord_IOS/AnglesRecord_IOS.xcodeproj/project.pbxproj
+++ b/AnglesRecord_IOS/AnglesRecord_IOS.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0981EA812E07B6DD00874A4F /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 0981EA802E07B6DD00874A4F /* FirebaseFunctions */; };
 		0981EA832E07B6DD00874A4F /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 0981EA822E07B6DD00874A4F /* FirebaseStorage */; };
 		0996B3312E2F0F2E00B57383 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 0996B3302E2F0F2E00B57383 /* FirebaseMessaging */; };
+		099802772E76C876006AE773 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 099802762E76C876006AE773 /* FirebaseRemoteConfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 				0981EA812E07B6DD00874A4F /* FirebaseFunctions in Frameworks */,
 				0981EA832E07B6DD00874A4F /* FirebaseStorage in Frameworks */,
 				0996B3312E2F0F2E00B57383 /* FirebaseMessaging in Frameworks */,
+				099802772E76C876006AE773 /* FirebaseRemoteConfig in Frameworks */,
 				0981EA7D2E07B6DD00874A4F /* FirebaseAuth in Frameworks */,
 				0981EA7F2E07B6DD00874A4F /* FirebaseFirestore in Frameworks */,
 			);
@@ -91,6 +93,7 @@
 				0981EA802E07B6DD00874A4F /* FirebaseFunctions */,
 				0981EA822E07B6DD00874A4F /* FirebaseStorage */,
 				0996B3302E2F0F2E00B57383 /* FirebaseMessaging */,
+				099802762E76C876006AE773 /* FirebaseRemoteConfig */,
 			);
 			productName = AnglesRecord_IOS;
 			productReference = 0981EA4E2E07B62700874A4F /* A'Cast.app */;
@@ -410,6 +413,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 0981EA7B2E07B6DD00874A4F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
+		};
+		099802762E76C876006AE773 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0981EA7B2E07B6DD00874A4F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/AnglesRecord_IOS/AnglesRecord_IOS/Application/AnglesRecord_IOSApp.swift
+++ b/AnglesRecord_IOS/AnglesRecord_IOS/Application/AnglesRecord_IOSApp.swift
@@ -19,16 +19,16 @@ struct AnglesRecord_IOSApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     @State private var authStatus: AuthStatus = .loading
     @StateObject private var playQueue = PlayQueueManager()
-
-    // ✅ 에피소드 리스트 ViewModel 전역 공유
     @StateObject private var recordListViewModel = RecordListViewModel()
 
-    /// ✅ EpisodeModel, RecordListModel을 모두 포함한 공유 컨테이너
+    // ⬇️ 추가: 업데이트 게이트 + 얼럿 표시용 플래그
+    @StateObject private var updateGate = UpdateGate()
+    @State private var showForceUpdateAlert = false
+    @Environment(\.scenePhase) private var scenePhase
+
     var sharedModelContainer: ModelContainer = {
-        let schema = Schema([
-            RecordListModel.self,
-            EpisodeModel.self  // ✅ 반드시 포함되어야 SwiftData에 저장됨
-        ])
+        let schema = Schema([ RecordListModel.self, EpisodeModel.self
+                            ])
         let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
         return try! ModelContainer(for: schema, configurations: [config])
     }()
@@ -37,35 +37,53 @@ struct AnglesRecord_IOSApp: App {
         WindowGroup {
             Group {
                 switch authStatus {
-                case .loading:
-                    SplashView()
-
-                case .authenticated:
-                    MainView()
-
-                case .unauthenticated:
-                    AuthView()
+                case .loading:         SplashView()
+                case .authenticated:   MainView()
+                case .unauthenticated: AuthView()
                 }
             }
-            .animation(.easeInOut(duration: 0.4), value: authStatus)
             .environmentObject(recordListViewModel)
             .environmentObject(playQueue)
-            .onAppear {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                    if let _ = KeychainHelper.load("verifiedAccessCode") {
-                        authStatus = .authenticated
-                    } else {
-                        authStatus = .unauthenticated
-                    }
 
-                    if isDeviceJailbroken() {
-                        print("🚨 탈옥 감지됨")
+            // 시작 시 1회 점검
+            .task { await updateGate.check() }
+
+            // 포그라운드 복귀 시 재점검
+            .onChange(of: scenePhase) { phase in
+                if phase == .active {
+                    Task { await updateGate.check() }
+                }
+            }
+
+            // UpdateGate 신호 → 얼럿 표시
+            .onReceive(updateGate.$forceUpdateRequired) { need in
+                if need { showForceUpdateAlert = true }
+            }
+
+            // 🔔 강제 업데이트 얼럿 (취소 버튼 없음)
+            .alert("업데이트가 필요합니다",
+                   isPresented: $showForceUpdateAlert) {
+                Button("앱스토어 열기") {
+                    if let url = URL(string: "itms-apps://itunes.apple.com/app/id/6748930317") {
+                        UIApplication.shared.open(url)
                     }
+                    // 앱으로 복귀하면 scenePhase == .active에서 다시 check되어
+                    // 최신 버전이 아니면 얼럿이 재등장 → 사실상 강제
+                }
+            } message: {
+                Text("안정적인 사용을 위해 최신 버전으로 업데이트 해주세요.")
+            }
+
+            .onAppear {
+                // (기존 인증 분기 로직)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                    authStatus = (KeychainHelper.load("verifiedAccessCode") != nil) ? .authenticated : .unauthenticated
                 }
             }
         }
-        .modelContainer(sharedModelContainer)  // ✅ 단일 컨테이너로 앱 전체 연결
+        .modelContainer(sharedModelContainer)
     }
+
 
     // MARK: - 유틸
 

--- a/AnglesRecord_IOS/AnglesRecord_IOS/Application/Coordinator/UpdateGate.swift
+++ b/AnglesRecord_IOS/AnglesRecord_IOS/Application/Coordinator/UpdateGate.swift
@@ -1,0 +1,105 @@
+//
+//  UpdateGate.swift
+//  A'Cast
+//
+//  Created by 성현 on 9/14/25.
+//
+
+import Foundation
+import Combine
+import FirebaseRemoteConfig
+
+final class UpdateGate: ObservableObject {
+    @Published var forceUpdateRequired = false
+    // (옵션) 디버깅용으로 내려받은 최소버전 확인하고 싶으면 활용
+    @Published var minSupportedVersion: String?
+
+    private var lastCheckedAt: Date?
+    private let rc = RemoteConfig.remoteConfig()
+
+    // 🔢 App Store numeric app ID (Bundle ID 안 씀)
+    private let appStoreID = "6748930317"
+
+    init() {
+        // 개발 중엔 즉시 반영, 운영은 기본(12h 캐시) 사용
+        #if DEBUG
+        let settings = RemoteConfigSettings()
+        settings.minimumFetchInterval = 0
+        rc.configSettings = settings
+        #endif
+
+        // 네트워크 실패 대비 기본값
+        rc.setDefaults([
+            "min_supported_version": "1.0.0" as NSObject
+        ])
+    }
+
+    /// 원격 최소 버전 확인 → 현재 버전과 비교 → 필요 시 강제 업데이트 플래그 ON
+    func check() async {
+        // 30분 이내 재호출 방지 (쓰로틀)
+        if let last = lastCheckedAt, Date().timeIntervalSince(last) < 30 * 60 { return }
+        lastCheckedAt = Date()
+
+        let current = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
+
+        // await를 ?? 에서 못 쓰므로 순차 분기
+        var minRequired: String? = await fetchMinSupportedVersion()
+        if minRequired == nil {
+            minRequired = await fetchAppStoreLatest() // iTunes Lookup fallback
+        }
+
+        if let min = minRequired {
+            await MainActor.run {
+                self.minSupportedVersion = min
+                if self.isVersion(current, olderThan: min) {
+                    self.forceUpdateRequired = true
+                }
+            }
+        }
+    }
+
+    // MARK: - Data Sources
+
+    /// Firebase Remote Config: key = "min_supported_version"
+    private func fetchMinSupportedVersion() async -> String? {
+        do {
+            try await rc.fetch(withExpirationDuration: 0)
+            _ = try await rc.activate()
+            let v = rc.configValue(forKey: "min_supported_version").stringValue ?? ""
+            return v.isEmpty ? nil : v
+        } catch {
+            return nil
+        }
+    }
+
+    /// iTunes Lookup (앱스토어 공개 상태여야 동작 안정적)
+    private func fetchAppStoreLatest() async -> String? {
+        guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(appStoreID)&country=kr") else {
+            return nil
+        }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard
+                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let results = json["results"] as? [[String: Any]],
+                let first = results.first,
+                let version = first["version"] as? String
+            else { return nil }
+            return version
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: - Semver compare (1.2.10 < 1.3 correctly)
+    private func isVersion(_ v1: String, olderThan v2: String) -> Bool {
+        func parts(_ v: String) -> [Int] { v.split(separator: ".").map { Int($0) ?? 0 } }
+        let a = parts(v1), b = parts(v2)
+        for i in 0..<max(a.count, b.count) {
+            let x = i < a.count ? a[i] : 0
+            let y = i < b.count ? b[i] : 0
+            if x != y { return x < y }
+        }
+        return false
+    }
+}


### PR DESCRIPTION
## 어떤 이슈와 관련있나요?
<!-- #과 함께 이슈번호를 넣으세요! -->
closes #106 

## 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
firebaseconfig를 1순위로, 앱스토어 버전을 2순위로 설정하여 새 버전이 있을 시, 앱을 자동으로 차단하는 로직을 updategate를 통해 구현하여, app단에 실행시키도록 진행하였습니다. 

<img width="784" height="350" alt="스크린샷 2025-09-14 오후 6 57 08" src="https://github.com/user-attachments/assets/1d73eb26-574d-4d6c-a802-c1b23bf7691b" />

이렇게 firebase에서 미니멈 버전을 개시하면

<img width="1179" height="2556" alt="IMG_3593" src="https://github.com/user-attachments/assets/68885f32-41d8-46c6-948b-accd644060bd" />
이렇게 차단이 되고, 앱 스토어에 저희 앱으로 넘어가게 진행하였습니다. (firebase에서 지금 앱 버전보다 미니멈을 낮게 설정했을 때, 알럿이 안뜨는것도 확인 완료)

## Others (선택)
> 리뷰어에게 전달하고 싶은 내용을 작성하세요.
