### PR TITLE
[Fix] MiniPlayerView 업데이트 안되는 문제 해결

### DIFF
--- a/AnglesRecord_IOS/AnglesRecord_IOS/Feature/Main/MainView.swift
+++ b/AnglesRecord_IOS/AnglesRecord_IOS/Feature/Main/MainView.swift
@@ -236,11 +236,28 @@ struct MainView: View {
                 print("📥 [\(TS())] 푸시 감지됨 → 자동 동기화")
                 Task { await refreshNow(trigger: "onAppear-flag") }
             }
+            
+            if let current = playQueue.current {
+                selectedRecord = current
+                miniPlayerEpisodeFileName = current.fileURL?.lastPathComponent
+            }
         }
         .onChange(of: shouldFetchNewEpisodes) { newVal in
             print("🔁 [\(TS())] shouldFetchNewEpisodes 변경: \(newVal)")
             if newVal {
                 Task { await refreshNow(trigger: "flag-onchange") }
+            }
+        }
+        .onReceive(playQueue.$currentIndex) { _ in
+            guard let current = playQueue.current else {
+                // 큐가 비면 미니플레이어 닫기
+                selectedRecord = nil
+                return
+            }
+            withAnimation(.spring()) {
+                selectedRecord = current
+                // 미니플레이어의 "다운로드 중" 표시 정확도를 위해 파일명도 같이 업데이트
+                miniPlayerEpisodeFileName = current.fileURL?.lastPathComponent
             }
         }
     }


### PR DESCRIPTION
## 어떤 이슈와 관련있나요?
<!-- #과 함께 이슈번호를 넣으세요! -->
Closes #130 

## 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
원인: MainView가 전역 큐(PlayQueueManager)의 @Published currentIndex 변화를 구독하지 않아 selectedRecord가 동기화되지 않았습니다.

조치

MainView에 .onReceive(playQueue.$currentIndex) 추가 → 변화 시 selectedRecord = playQueue.current로 동기화, miniPlayerEpisodeFileName도 함께 갱신(스프링 애니메이션).

앱 진입/복원 시 초기 상태 불일치 방지를 위해 onAppear에서 스냅샷 복원값으로 한 번 더 동기화.

큐가 비면 selectedRecord = nil로 설정하여 미니플레이어를 자연스럽게 닫도록 처리.

## Others (선택)
> 리뷰어에게 전달하고 싶은 내용을 작성하세요.
