### PR TITLE
fix: 패딩값 수정 및 divider 제거 #134

### DIFF
--- a/AnglesRecord_IOS/AnglesRecord_IOS/Feature/Main/MainView.swift
+++ b/AnglesRecord_IOS/AnglesRecord_IOS/Feature/Main/MainView.swift
@@ -127,14 +127,13 @@ struct MainView: View {
                             }
                             .padding(.trailing, 20)
                         }
-                        .padding(.top, 8)
+                        .padding(.top, 4)
                     
                         podcastMainSection
                         
                         descriptionSection
                     }
                     
-                    Divider().padding(.horizontal)
                     
                     if recordListViewModel.isLoadingEpisodes {
                         loadingSection
@@ -386,7 +385,7 @@ struct MainView: View {
                 .scaledToFit()
                 .frame(width: 200, height: 200)
                 .cornerRadius(8)
-                .padding(.top, 41)
+                .padding(.top, 20)
             
             Text("전지적 씨팝 시점: 전팝시")
                 .font(Font.SFPro.SemiBold.s16)
@@ -442,7 +441,7 @@ struct MainView: View {
                 VStack(spacing: 0) {
                     episodeRow(for: episode)
                         .padding(.horizontal, 20)
-                        .padding(.vertical, 16)
+                        .padding(.top, index == 0 ? 32 : 16)
                     
                     if index < recordListViewModel.episodes.count - 1 {
                         Divider().padding(.horizontal, 20)
@@ -455,7 +454,7 @@ struct MainView: View {
     }
     
     private func episodeRow(for episode: EpisodeModel) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 4) {
             Text(formatted(date: episode.uploadedAt))
                 .font(Font.SFPro.SemiBold.s12)
                 .foregroundColor(Color("subText"))
@@ -476,11 +475,13 @@ struct MainView: View {
                 }
             }
             .frame(width: 345, alignment: .leading)
+            .padding(.bottom, 8)
 
             Text(episode.desc)
                 .font(Font.SFPro.Regular.s14)
                 .foregroundColor(Color("subText"))
                 .lineLimit(2)
+                .padding(.bottom, 12)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())


### PR DESCRIPTION
## 어떤 이슈와 관련있나요?
<!-- #과 함께 이슈번호를 넣으세요! -->
Closes #134

## 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 패딩값 수정
- divider 제거
- 좌: 시뮬레이터 View / 우: 피그마 원본
<img width="323" height="352" alt="스크린샷 2025-09-19 오후 5 02 54" src="https://github.com/user-attachments/assets/3e22a590-0813-4937-b486-faa6635b239f" />


## 참고 자료 (선택)
-
-

## Others (선택)
> 리뷰어에게 전달하고 싶은 내용을 작성하세요.
